### PR TITLE
fix "Value passed for the token was invalid"

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -62,7 +62,7 @@ const generateLoginData = async (code, codeVerifier) => {
     console.log(code);
     let loginData = await twitterClient.loginWithOAuth2({
         code: code,
-        redirect_uri: 'http://localhost:6969/v2/callback',
+        redirectUri: 'http://localhost:6969/v2/callback',
         codeVerifier: codeVerifier
     }).catch(err => {
         console.log(err);


### PR DESCRIPTION
Hey I finally found the issue :)

The Twitter API returns this error when the redirect URI is missing

It totally didn't take me 2 hours to figure this out